### PR TITLE
Board vs BCM changes, M600 changes, and false positive detection

### DIFF
--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -206,13 +206,13 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                         GPIO.add_event_detect(
                             self.pin, GPIO.RISING,
                             callback=self.sensor_callback,
-                            bouncetime=500
+                            bouncetime=5000
                         )
                     else:
                         GPIO.add_event_detect(
                             self.pin, GPIO.FALLING,
                             callback=self.sensor_callback,
-                            bouncetime=500
+                            bouncetime=5000
                         )
             # Disable sensor
             elif event in (

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -54,7 +54,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
         try:
             selected_power = int(data.get("power"))
             selected_pin = int(data.get("pin"))
-            GPIO.setmode(GPIO.BOARD)
+            GPIO.setmode(GPIO.BCM)
             # first check pins not in use already
             usage = GPIO.gpio_function(selected_pin)
             self._logger.debug("usage on pin %s is %s" % (selected_pin, usage))
@@ -107,8 +107,8 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
     def _setup_sensor(self):
         if self.sensor_enabled():
-            self._logger.info("Setting up sensor using board mode.")
-            GPIO.setmode(GPIO.BOARD)
+            self._logger.info("Setting up sensor using BCM mode.")
+            GPIO.setmode(GPIO.BCM)
             self._logger.info("Filament Sensor active on GPIO Pin [%s]" % self.pin)
             if self.switch is 0:
                 GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -130,7 +130,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                     self.changing_filament_started = False
                     if self.no_filament():
                         self.send_out_of_filament()
-            if cmd == "M600 X0 Y0":
+            if cmd == "M600":
                 self.changing_filament_started = True
 
     def gcode_response_received(self, comm, line, *args, **kwargs):
@@ -236,7 +236,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
     def send_out_of_filament(self):
         self.show_printer_runout_popup()
         self._logger.info("Sending out of filament GCODE")
-        self._printer.commands("M600 X0 Y0")
+        self._printer.commands("M600")
         self.changing_filament_initiated = True
 
     def show_printer_runout_popup(self):

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -205,13 +205,13 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                     if self.switch is 0:
                         GPIO.add_event_detect(
                             self.pin, GPIO.RISING,
-                            callback=self.sensor_callback,
+                            callback=self.sensor_callback_high,
                             bouncetime=5000
                         )
                     else:
                         GPIO.add_event_detect(
                             self.pin, GPIO.FALLING,
-                            callback=self.sensor_callback,
+                            callback=self.sensor_callback_low,
                             bouncetime=5000
                         )
             # Disable sensor
@@ -227,9 +227,23 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                 self.changing_filament_started = False
                 self.paused_for_user = False
 
-    def sensor_callback(self, _):
+    def sensor_callback_high(self, _):
         sleep(1)
-        self._logger.info("Sensor was triggered")
+        self._logger.info("Sensor was triggered high")
+        sleep(60)
+        if GPIO.input(self.pin) != GPIO.HIGH:
+            self._logger.info("Sensor was false positive high")
+            return
+        if not self.changing_filament_initiated:
+            self.send_out_of_filament()
+
+    def sensor_callback_low(self, _):
+        sleep(1)
+        self._logger.info("Sensor was triggered low")
+        sleep(60)
+        if GPIO.input(self.pin) != GPIO.LOW:
+            self._logger.info("Sensor was false positive low")
+            return
         if not self.changing_filament_initiated:
             self.send_out_of_filament()
 

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -206,13 +206,13 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                         GPIO.add_event_detect(
                             self.pin, GPIO.RISING,
                             callback=self.sensor_callback_high,
-                            bouncetime=5000
+                            bouncetime=40000
                         )
                     else:
                         GPIO.add_event_detect(
                             self.pin, GPIO.FALLING,
                             callback=self.sensor_callback_low,
-                            bouncetime=5000
+                            bouncetime=40000
                         )
             # Disable sensor
             elif event in (
@@ -228,23 +228,19 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                 self.paused_for_user = False
 
     def sensor_callback_high(self, _):
-        sleep(1)
         self._logger.info("Sensor was triggered high")
-        sleep(60)
+        sleep(30)
         if GPIO.input(self.pin) != GPIO.HIGH:
-            self._logger.info("Sensor was false positive high")
-            return
-        if not self.changing_filament_initiated:
+            return self._logger.info("Sensor was false positive high")
+        elif not self.changing_filament_initiated:
             self.send_out_of_filament()
 
     def sensor_callback_low(self, _):
-        sleep(1)
         self._logger.info("Sensor was triggered low")
-        sleep(60)
+        sleep(30)
         if GPIO.input(self.pin) != GPIO.LOW:
-            self._logger.info("Sensor was false positive low")
-            return
-        if not self.changing_filament_initiated:
+            return self._logger.info("Sensor was false positive low")
+        elif not self.changing_filament_initiated:
             self.send_out_of_filament()
 
     def send_out_of_filament(self):

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -206,13 +206,13 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                         GPIO.add_event_detect(
                             self.pin, GPIO.RISING,
                             callback=self.sensor_callback_high,
-                            bouncetime=40000
+                            bouncetime=7000
                         )
                     else:
                         GPIO.add_event_detect(
                             self.pin, GPIO.FALLING,
                             callback=self.sensor_callback_low,
-                            bouncetime=40000
+                            bouncetime=7000
                         )
             # Disable sensor
             elif event in (
@@ -229,7 +229,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
     def sensor_callback_high(self, _):
         self._logger.info("Sensor was triggered high")
-        sleep(30)
+        sleep(5)
         if GPIO.input(self.pin) != GPIO.HIGH:
             return self._logger.info("Sensor was false positive high")
         elif not self.changing_filament_initiated:
@@ -237,7 +237,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
     def sensor_callback_low(self, _):
         self._logger.info("Sensor was triggered low")
-        sleep(30)
+        sleep(5)
         if GPIO.input(self.pin) != GPIO.LOW:
             return self._logger.info("Sensor was false positive low")
         elif not self.changing_filament_initiated:

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -206,13 +206,13 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                         GPIO.add_event_detect(
                             self.pin, GPIO.RISING,
                             callback=self.sensor_callback,
-                            bouncetime=250
+                            bouncetime=500
                         )
                     else:
                         GPIO.add_event_detect(
                             self.pin, GPIO.FALLING,
                             callback=self.sensor_callback,
-                            bouncetime=250
+                            bouncetime=500
                         )
             # Disable sensor
             elif event in (

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
@@ -4,7 +4,7 @@
         <div class="marginBot">
             <b>Which Raspberry Pi pin your sensor output is attached to (-1 disables the plugin)</b>
         </div>
-        <label class="control-label">{{ _('Board pin number:') }}</label>
+        <label class="control-label">{{ _('BCM pin number:') }}</label>
         <div class="controls" data-toggle="tooltip">
             <input id="pinInput" type="number" step="1" min="-1" max="40" class="input-mini text-right"
                    data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.pin">


### PR DESCRIPTION
I do really like the simplicity of this plugin, it looks good, and it works! Unlike a lot of the others. I did solve a few issues for myself that may benefit others.

1. This plugin was conflicting with the octoprint.enclosure plugin. Enclosure was setting all the pins in BCM mode and would not allow this plugin to set in BOARD mode. I changed a few gpio.board lines as well as the plugin setup screen.

2. I didn't like the 'M600 X0 Y0' as I have hard coded my own values into my firmware and I'm sure this will be different for everyone.

3.
> Here is what I did to fix my noisy switch
> 
> ```
>                     if self.switch is 0:
>                          GPIO.add_event_detect(
>                             self.pin, GPIO.RISING,
>                             callback=self.sensor_callback_high,
>                             bouncetime=40000
>                         )
>                     else:
>                         GPIO.add_event_detect(
>                             self.pin, GPIO.FALLING,
>                             callback=self.sensor_callback_low,
>                             bouncetime=40000
>                         )
> ```
> You will notice I have separated the callback functions and my bouncetime is 40 seconds. What that means is that it will not activate the callback function for another 40 seconds giving that function time to do it's thing.
> 
> My call back functions:
> 
> ```
>     def sensor_callback_high(self, _):
>         self._logger.info("Sensor was triggered high")
>         sleep(30)
>         if GPIO.input(self.pin) != GPIO.HIGH:
>             return self._logger.info("Sensor was false positive high")
>         elif not self.changing_filament_initiated:
>             self.send_out_of_filament()
> 
>     def sensor_callback_low(self, _):
>         self._logger.info("Sensor was triggered low")
>         sleep(30)
>         if GPIO.input(self.pin) != GPIO.LOW:
>             return self._logger.info("Sensor was false positive low")
>         elif not self.changing_filament_initiated:
>             self.send_out_of_filament()
> ```
> What this does is first print on the log it was triggered (high or low/ground or 3V3). I did this for troubleshooting purposes.
> Then it waits 30 seconds to verify the pin is indeed still in the triggered state.
> If it is not, print on the log false positive.
> If it is, send M600
> 
> The biggest key here is making sure your bouncetime is LONGER than your callback function.
> My sensor is far enough away from the extruder I can spare 30 seconds.
> 

I have to imagine you can make all of these options configurable on the plugin setup page. This is what works for me