### PR TITLE
Add fallback to use M25 if M600 isn't supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This plugin reacts to short lever microswitch output like [this](https://chinadaier.en.made-in-china.com/product/ABVJkvyMAqcT/China-1A-125VAC-on-off-Kw10-Mini-Micro-Mouse-Switch.html)
 If triggered (switch open) it issues **M600 X0 Y0** command to printer.
+If the printer does not support the **M600** command, it will send **M25** instead which will trigger OctoPrint's pause gcode.
 
 Let's check some features:
 * pop-up notification when printer runs out of filament
@@ -9,7 +10,7 @@ Let's check some features:
 * test button so you know if your sensor really works or not
 * filament check at the start of the print - if no filament present it won't start printing, again pop-up will appear
 * filament check at the end of filament change - just to be sure you won't start printing with no filament
-* check if printer supports M600 when printer connected - if not user will be notified through pop-up
+* check if printer supports M600 when printer connected - if not, M25 will be used instead and user will be notified through pop-up
 * info pop-up when plugin hasn't been configured
 * filament runouts can be repeatable which didn't work with other plugins I tried
 * user-friendly and easy to configure

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -123,7 +123,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
         self._printer.commands("M603")
 
     def sending_gcode(self, comm_instance, phase, cmd, cmd_type, gcode, subcode=None, tags=None, *args, **kwargs):
-        if self.changing_filament_initiated and self.m600Enabled:
+        if self.changing_filament_initiated:
             if self.changing_filament_started:
                 if not re.search("^M113", cmd):
                     self.changing_filament_initiated = False


### PR DESCRIPTION
As many printers don't support M600, a logical reversion to M25 should be automatic when M600 isn't available.

Use case: I control my printer exclusively through OctoPi and don't even have an LCD controller connected. Therefore I cannot enable the advanced parking feature which is needed for M600 to even be enabled. I can however configure my pause G-Code in OctoPrint to function essentially in the same way. Therefore M25 is my only pausing / filament change option.

Changes:
 - Line 137: Remove self.m600Enabled check in gcode_response_received 
 - Line 159: Update startup message to denote whether the plugin is reverting to M25
 - Line 194: Remove "if self.m600Enabled:" requirement to activate sensor
 - Line 237-242: Add logic toggle in send_out_of_filament to send original M600 or M25 based on self.m600Enabled