### PR TITLE
Add signal verifications to clean up false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Let's check some features:
 * test button so you know if your sensor really works or not
 * filament check at the start of the print - if no filament present it won't start printing, again pop-up will appear
 * filament check at the end of filament change - just to be sure you won't start printing with no filament
+* user defined number of verification checks - handy to mitigate false triggers from noisy signal wires
 * check if printer supports M600 when printer connected - if not user will be notified through pop-up
 * info pop-up when plugin hasn't been configured
 * filament runouts can be repeatable which didn't work with other plugins I tried
@@ -40,6 +41,8 @@ Default pin is -1 (not configured) and ground (as it is safer, read below).
 You might experience the same problem as I experienced - the sensor was randomly triggered. Turns out that if running sensor wires along motor wires, it was enough to interfere with sensor reading.
 
 To solve this connect a shielded wire to your sensor and ground the shielding, ideally on both ends.
+
+If this still does not solve the random trigger issue, or you are unable to implement these solutions, you can increase the number of verification checks in the settings. Note: Each verification takes 0.05 seconds, so if your sensor is very close to your extruder, you may not want to set this number too high. I found 5-10 verifications to be more than sufficient in my testing.
 
 If you are unsure about your sensor being triggered, check [OctoPrint logs](https://community.octoprint.org/t/where-can-i-find-octoprints-and-octopis-log-files/299)
 

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -128,7 +128,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
         self._printer.commands("M603")
 
     def sending_gcode(self, comm_instance, phase, cmd, cmd_type, gcode, subcode=None, tags=None, *args, **kwargs):
-        if self.changing_filament_initiated and self.m600Enabled:
+        if self.changing_filament_initiated:
             if self.changing_filament_started:
                 if not re.search("^M113", cmd):
                     self.changing_filament_initiated = False
@@ -233,12 +233,10 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                 self.paused_for_user = False
 
     def sensor_callback(self, _):
-        counter = 0
         trigger = True
-        while counter < self.verifications:
+        for x in range(0, self.verifications):
             sleep(0.05)
-            counter = counter + 1
-            if GPIO.input(self.pin) == 0:
+            if self.no_filament() == False:
                 trigger = False
                 
         if trigger:

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -128,14 +128,14 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
         self._printer.commands("M603")
 
     def sending_gcode(self, comm_instance, phase, cmd, cmd_type, gcode, subcode=None, tags=None, *args, **kwargs):
-        if self.changing_filament_initiated:
+        if self.changing_filament_initiated and self.m600Enabled:
             if self.changing_filament_started:
                 if not re.search("^M113", cmd):
                     self.changing_filament_initiated = False
                     self.changing_filament_started = False
                     if self.no_filament():
                         self.send_out_of_filament()
-            if cmd == "M600 X0 Y0" or cmd == "M25":
+            if cmd == "M600 X0 Y0":
                 self.changing_filament_started = True
 
     def gcode_response_received(self, comm, line, *args, **kwargs):

--- a/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
+++ b/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
@@ -29,7 +29,8 @@ $(function () {
                     data: JSON.stringify({
                         "command": "testSensor",
                         "pin": $("#pinInput").val(),
-                        "power": $("#powerInput").val()
+                        "power": $("#powerInput").val(),
+						"verifications": $("#verifications").val()
                     }),
                     statusCode: {
                         500: function () {

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
@@ -14,7 +14,7 @@
         </div>
 		<label class="control-label">{{ _('Verifications:') }}</label>
 		<div class="controls" data-toggle="tooltip">
-            <input id="verifications" type="number" step="1" min="1" max="40" class="input-mini text-right"
+            <input id="verifications" type="number" step="1" min="1" max="100" class="input-mini text-right"
                    data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.verifications">
         </div>
     </div>

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
@@ -9,6 +9,14 @@
             <input id="pinInput" type="number" step="1" min="-1" max="40" class="input-mini text-right"
                    data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.pin">
         </div>
+		<div class="marginBot">
+            <b>How many signal verifications are needed to trigger filament runout (each verification takes 0.05 seconds)</b>
+        </div>
+		<label class="control-label">{{ _('Verifications:') }}</label>
+		<div class="controls" data-toggle="tooltip">
+            <input id="verifications" type="number" step="1" min="1" max="40" class="input-mini text-right"
+                   data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.verifications">
+        </div>
     </div>
     <div class="control-group">
         <div class="marginBot">


### PR DESCRIPTION
Use case: Noisy GPIO inputs cause signal dropouts occasionally, falsely triggering a filament runout command. The callback should verify the pin value 1 or more times before sending the runout command.

Simply increasing the bouncetime is not a viable solution as there appears to be a bug in the RPi.GPIO library according to https://shallowsky.com/blog/hardware/buttons-on-raspberry-pi.html

The author of the above article describes an alternative signal confirmation solution which I have adapted for use with this plugin.

Changes:
 - Adds new GUI field "Verifications". This allows the user to input how many signal verifications are needed to confirm a runout has occurred.
 - Adds a for loop in the callback to check the sensor with a 0.05 second delay between each check. Any failed verifications will abort sending the runout command.