### PR TITLE
Remove duplicate command and notification during filament runout

### DIFF
--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -128,8 +128,6 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                 if not re.search("^M113", cmd):
                     self.changing_filament_initiated = False
                     self.changing_filament_started = False
-                    if self.no_filament():
-                        self.send_out_of_filament()
             if cmd == "M600 X0 Y0":
                 self.changing_filament_started = True
 


### PR DESCRIPTION
Use Case: self.send_out_of_filament method is called twice for each runout. This triggers the notification popup twice, as well as sends the gcode to the printer twice - these should only occur once per runout.

This method is called both in sending_gcode on lines 131-132, and also in sensor_callback on line 232.

Changes:
 Lines 131-132: Removed self.send_out_of_filament() from sending_gcode as this method is already called in the callback attached to the pin.