### PR TITLE
Native OP pause + Navbar/Topbar icon

### DIFF
--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -129,7 +129,6 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 			if self.detectionOn == False and (timenow - self.ui_status) >= 60:
 				if self.setupGPIO():
 					self.no_filament()
-			self._logger.info(self.last_status)
 			return flask.jsonify({'status' : self.last_status})
 
 		try:

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -308,8 +308,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 				self._logger.debug("Printer doesn't support M600")
 				self.M600_supported = False
 				self.checking_M600 = False
-				self._plugin_manager.send_plugin_message(self._identifier, dict(type="info", autoClose=True,
-																				msg="M600 gcode command is not enabled on this printer! This plugin won't work."))
+				self._settings.set(["cmd_action"], "opnative")
 			else:
 				self._logger.debug("M600 check unsuccessful, trying again")
 				self.checkM600Enabled()

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -430,7 +430,8 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
 	def send_out_of_filament(self):
 		self.show_printer_runout_popup()
-		if self.cmd_action == "gcode":
+		cmd_action = self._settings.get(["cmd_action"])
+		if cmd_action == "gcode":
 			self._logger.info("Sending out of filament GCODE: %s" % (self.g_code))
 			self._printer.commands(self.g_code)
 		else:

--- a/octoprint_filamentsensorsimplified/static/css/filamentsensorsimplified.css
+++ b/octoprint_filamentsensorsimplified/static/css/filamentsensorsimplified.css
@@ -14,7 +14,3 @@
     animation-iteration-count: 1;
 }
 
-#filamentsensorsimplified_settings_testResult{
-	display: block;
-	float: right;
-}

--- a/octoprint_filamentsensorsimplified/static/css/filamentsensorsimplified.css
+++ b/octoprint_filamentsensorsimplified/static/css/filamentsensorsimplified.css
@@ -16,5 +16,5 @@
 
 #filamentsensorsimplified_settings_testResult{
 	display: block;
-	margin-bottom: 10px;
+	float: right;
 }

--- a/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
+++ b/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
@@ -24,7 +24,7 @@ $(function () {
                         self.updateIconStatus(response.status);
                     }
                 });
-            }, 50000);
+            }, 65000);
         }
 
         self.updateIconStatus = function(noFilament){

--- a/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
+++ b/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
@@ -16,6 +16,18 @@ $(function () {
                 return;
             }
 
+            // Update icon
+            if (data.type == "iconStatus"){
+                if (data.noFilament){
+                    $('#navbar_plugin_filamentsensorsimplified i').replaceWith('<i class="text-error fas fa-dot-circle"></i>');
+                    $('#navbar_plugin_filamentsensorsimplified a').attr('title','Filament NOT detected');
+                }else{
+                    $('#navbar_plugin_filamentsensorsimplified i').replaceWith('<i class="text-success fas fa-circle"></i>');
+                    $('#navbar_plugin_filamentsensorsimplified a').attr('title','Filament detected');
+                }
+                return;
+            }
+
             new PNotify({
                 title: 'Filament sensor simplified',
                 text: data.msg,

--- a/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
+++ b/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
@@ -11,6 +11,32 @@ $(function () {
             return this.gpio_mode_disabled() && !this.printing();
         }, this);
 
+        self.onAllBound = function(){
+            // First run
+            OctoPrint.simpleApiCommand("filamentsensorsimplified", "pollStatus", {}).done(function(response) {
+                if ('status' in response){
+                    self.updateIconStatus(response.status);
+                }
+            });
+            setInterval(function(){
+                OctoPrint.simpleApiCommand("filamentsensorsimplified", "pollStatus", {}).done(function(response) {
+                    if ('status' in response){
+                        self.updateIconStatus(response.status);
+                    }
+                });
+            }, 50000);
+        }
+
+        self.updateIconStatus = function(noFilament){
+            if (noFilament){
+                $('#navbar_plugin_filamentsensorsimplified i').replaceWith('<i class="text-error fas fa-dot-circle"></i>');
+                $('#navbar_plugin_filamentsensorsimplified a').attr('title','Filament NOT detected');
+            }else{
+                $('#navbar_plugin_filamentsensorsimplified i').replaceWith('<i class="text-success fas fa-circle"></i>');
+                $('#navbar_plugin_filamentsensorsimplified a').attr('title','Filament detected');
+            }
+        }
+
         self.onDataUpdaterPluginMessage = function (plugin, data) {
             if (plugin !== "filamentsensorsimplified") {
                 return;
@@ -18,13 +44,7 @@ $(function () {
 
             // Update icon
             if (data.type == "iconStatus"){
-                if (data.noFilament){
-                    $('#navbar_plugin_filamentsensorsimplified i').replaceWith('<i class="text-error fas fa-dot-circle"></i>');
-                    $('#navbar_plugin_filamentsensorsimplified a').attr('title','Filament NOT detected');
-                }else{
-                    $('#navbar_plugin_filamentsensorsimplified i').replaceWith('<i class="text-success fas fa-circle"></i>');
-                    $('#navbar_plugin_filamentsensorsimplified a').attr('title','Filament detected');
-                }
+                self.updateIconStatus(data.noFilament);
                 return;
             }
 

--- a/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
+++ b/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
@@ -29,11 +29,9 @@ $(function () {
 
         self.updateIconStatus = function(noFilament){
             if (noFilament){
-                $('#navbar_plugin_filamentsensorsimplified i').replaceWith('<i class="text-error fas fa-dot-circle"></i>');
-                $('#navbar_plugin_filamentsensorsimplified a').attr('title','Filament NOT detected');
+                $('#navbar_plugin_filamentsensorsimplified a').html('<span class="fa-stack fa-1x"><i class="fas fa-life-ring fa-stack-1x"></i><i class="fas fa-ban fa-stack-2x text-error"></i></span>').attr('title','Filament NOT detected');
             }else{
-                $('#navbar_plugin_filamentsensorsimplified i').replaceWith('<i class="text-success fas fa-circle"></i>');
-                $('#navbar_plugin_filamentsensorsimplified a').attr('title','Filament detected');
+                $('#navbar_plugin_filamentsensorsimplified a').html('<i class="fas fa-life-ring fa-lg"></i>').attr('title','Filament detected');
             }
         }
 
@@ -59,7 +57,7 @@ $(function () {
 
         self.testSensor = function () {
             // Cleanup
-            $("#filamentsensorsimplified_settings_testResult").removeClass("text-warning text-error text-info text-success");
+            $("#filamentsensorsimplified_settings_testResult").hide().removeClass("hide alert-warning alert-error alert-info alert-success");
             // Make api callback
             $.ajax({
                     url: "/api/plugin/filamentsensorsimplified",
@@ -76,45 +74,47 @@ $(function () {
                     }),
                     statusCode: {
                         500: function () {
-                            $("#filamentsensorsimplified_settings_testResult").addClass("text-error");
+                            $("#filamentsensorsimplified_settings_testResult").addClass("alert-error");
                             self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> OctoPrint experienced a problem. Check octoprint.log for further info.');
                         },
                         555: function () {
-                            $("#filamentsensorsimplified_settings_testResult").addClass("text-error");
+                            $("#filamentsensorsimplified_settings_testResult").addClass("alert-error");
                             self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> This pin is already in use, choose other pin.');
                         },
                         556: function () {
-                            $("#filamentsensorsimplified_settings_testResult").addClass("text-error");
+                            $("#filamentsensorsimplified_settings_testResult").addClass("alert-error");
                             self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> The pin selected is power, ground or out of range pin number, choose other pin');
                         }
                     },
                     error: function () {
-                        $("#filamentsensorsimplified_settings_testResult").addClass("text-error");
+                        $("#filamentsensorsimplified_settings_testResult").addClass("alert-error");
                         self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> There was an error :(');
                     },
                     success: function (result) {
                         // triggered when open
                         if ($("#filamentsensorsimplified_settings_triggeredInput").val() === "0") {
                             if (result.triggered === true) {
-                                $("#filamentsensorsimplified_settings_testResult").addClass("text-success");
+                                $("#filamentsensorsimplified_settings_testResult").addClass("alert-success");
                                 self.testSensorResult('<i class="fas icon-ok fa-check"></i> Sensor detected filament!');
                             } else {
-                                $("#filamentsensorsimplified_settings_testResult").addClass("text-info");
+                                $("#filamentsensorsimplified_settings_testResult").addClass("alert-info");
                                 self.testSensorResult('<i class="icon-stop"></i> Sensor triggered!')
                             }
                         // triggered when closed
                         } else {
                             if (result.triggered === true) {
-                                $("#filamentsensorsimplified_settings_testResult").addClass("text-success");
+                                $("#filamentsensorsimplified_settings_testResult").addClass("alert-success");
                                 self.testSensorResult('<i class="fas icon-ok fa-check"></i> Sensor triggered!');
                             } else {
-                                $("#filamentsensorsimplified_settings_testResult").addClass("text-info");
+                                $("#filamentsensorsimplified_settings_testResult").addClass("alert-info");
                                 self.testSensorResult('<i class="icon-stop"></i> Sensor detected filament or not working!')
                             }
                         }
-                    }
+                    },
                 }
-            );
+            ).always(function(){
+                $("#filamentsensorsimplified_settings_testResult").fadeIn();
+            });
         }
         self.checkWarningPullUp = function(event){
             // Which mode are we using

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_navbar.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_navbar.jinja2
@@ -1,1 +1,1 @@
-<a title="Waiting..."><i class="muted fas fa-circle"></i></a>
+<a title="Waiting..."><i class="fas fa-life-ring muted"></i></a>

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_navbar.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_navbar.jinja2
@@ -1,0 +1,1 @@
+<a title="Waiting..."><i class="muted fas fa-circle"></i></a>

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
@@ -56,7 +56,7 @@
         </div>
     </div>
 
-    <h3>{{ _('Filament out action') }}</h3>
+    <h3>{{ _('Filament run out action') }}</h3>
     <div class="control-group">
         <label class="control-label" for="filamentsensorsimplified_settings_commandInput">{{ _('Action') }}</label>
         <div class="controls">
@@ -64,7 +64,6 @@
                 <option value="gcode">{{ _('Send G-code') }}</option>
                 <option value="opnative">{{ _('OctoPrint pause') }}</option>
             </select>
-            <span class="help-block">When filament out is detected shall we send G-code to the printer or use OctoPrints pause function.</span>
         </div>
         <div class="controls" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 'gcode'">
             <br/>
@@ -77,7 +76,7 @@
     <div class="control-group">
         <div class="controls">
             <input type="button" class="btn btn-info" data-bind="click: testSensor, disable:printing" value="Test sensor">
-            <strong id="filamentsensorsimplified_settings_testResult" data-bind="html: testSensorResult"></strong>
+            <div id="filamentsensorsimplified_settings_testResult" class="hide alert" data-bind="html: testSensorResult"></div>
         </div>
     </div>
 

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
@@ -1,10 +1,9 @@
-<h3>{{ _('Filament Sensor Simplified') }}</h3>
 <form id="filamentsensorsimplified_settings" class="form-horizontal">
     <div class="alert alert-info" data-bind="visible: printing">
         <i class="fas icon-lock fa-hourglass-half  iconRight"></i>
         {{ _('All settings are disabled while printing') }}
     </div>
-
+    <h3>{{ _('Sensor setup') }}</h3>
     <div class="control-group">
         <label class="control-label" for="filamentsensorsimplified_settings_gpioMode">{{ _('Board mode') }}</label>
         <div class="controls">
@@ -39,6 +38,10 @@
                 <option value=1>{{ _('3.3V') }}</option>
             </select>
             <span class="help-block">Specify how the sensor (switch) is connected. One end of the sensor must be wired to ground or 3.3V.</span>
+            <div class="alert alert-error">
+                <i class="fas fa-exclamation icon-warning-sign iconRight"></i>
+                Warning! Never connect the sensor to 5V! 5V could destroy GPIO of your Raspberry Pi.
+            </div>
         </div>
     </div>
 
@@ -53,18 +56,28 @@
         </div>
     </div>
 
+    <h3>{{ _('Filament out action') }}</h3>
     <div class="control-group">
-        <label class="control-label" for="filamentsensorsimplified_settings_commandInput">{{ _('Command to send') }}</label>
+        <label class="control-label" for="filamentsensorsimplified_settings_commandInput">{{ _('Action') }}</label>
         <div class="controls">
-            <input id="filamentsensorsimplified_settings_commandInput" type="text" class="input-large" data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.g_code, disable:printing">
+            <select data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action, disable:printing" required>
+                <option value="gcode">{{ _('Send G-code') }}</option>
+                <option value="opnative">{{ _('OctoPrint pause') }}</option>
+            </select>
+            <span class="help-block">When filament out is detected shall we send G-code to the printer or use OctoPrints pause function.</span>
+        </div>
+        <div class="controls" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 'gcode'">
+            <br/>
             <span class="help-block">Which G-code will be sent to printer on filament runout.</span>
+            <input id="filamentsensorsimplified_settings_commandInput" type="text" class="input-large" data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.g_code, disable:printing">
         </div>
     </div>
 
+    <h3>{{ _('Test sensor') }}</h3>
     <div class="control-group">
         <div class="controls">
-            <strong id="filamentsensorsimplified_settings_testResult" data-bind="html: testSensorResult"></strong>
             <input type="button" class="btn btn-info" data-bind="click: testSensor, disable:printing" value="Test sensor">
+            <strong id="filamentsensorsimplified_settings_testResult" data-bind="html: testSensorResult"></strong>
         </div>
     </div>
 
@@ -73,10 +86,6 @@
         Pins 3 and 5 (Board mode) or pins 2 and 3 (BCM mode) have physical pull up resistor. If sensor is connected to 3.3V this plugin won't work.
     </div>
     <br>
-    <div class="alert alert-error">
-        <i class="fas fa-exclamation icon-warning-sign iconRight"></i>
-        Warning! Never connect the sensor to 5V! 5V could destroy GPIO of your Raspberry Pi.
-    </div>
 
     <p>For more information click <a target="_blank" href="https://github.com/LuckyX182/Filament_sensor_simplified">here</a></p>
 


### PR DESCRIPTION
Added the following:
- Added option for allowing to use the native OctoPrint pause function instead of Gcode - some printers, my Anycubic included, reports support Gcode pause both dont honor them, so I added this option. Its default is to use Gcode. (Under settings "Filament out action")
- Implemented an navbar/topbar icon to show filament status - when not printing the UI will poll every 65 seconds. The backend caches results and will reply with that. The cache is expired when older than 60 seconds
- Did a bit of refactoring in the backend - made a setupGPIO function to enable handling the GPIO setup when polled
- Small settings changes to support the new native OP pause