### PR TITLE
Trigger filament change event so other plugins can react

### DIFF
--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import octoprint.plugin
 import re
-from octoprint.events import Events
+from octoprint.events import Events, eventManager
 from time import sleep
 import time
 import RPi.GPIO as GPIO
@@ -478,6 +478,7 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
 	def send_out_of_filament(self):
 		self.show_printer_runout_popup()
+		eventManager().fire(Events.FILAMENT_CHANGE)
 		cmd_action = self._settings.get(["cmd_action"])
 		if cmd_action == "gcode":
 			self._logger.info("Sending out of filament GCODE: %s" % (self.g_code))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_filamentsensorsimplified"
 plugin_name = "Filament sensor simplified"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.3"
+plugin_version = "0.2.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
This PR triggers the `FILAMENT_CHANGE` event similar to what OctoPrint does when an M600 is detected. This allows other plugins to react to the filament change request, in my case the OctoApp companion plugin will send a push notification to alert the user.

Change was tested by the user reporting the missing notification and confirmed working.