### PR TITLE
Added additional error info when testing, custom events, and "Do nothing" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Please note:
+
+This is a fork of the [original Filament Sensor Simplified plugin.](https://github.com/LuckyX182/Filament_sensor_simplified)
+
 # Filament sensor simplified
 
 This plugin reacts to short lever microswitch output like [this](https://chinadaier.en.made-in-china.com/product/ABVJkvyMAqcT/China-1A-125VAC-on-off-Kw10-Mini-Micro-Mouse-Switch.html)
@@ -52,19 +56,6 @@ You might experience the same problem as I experienced - the sensor was randomly
 To solve this connect a shielded wire to your sensor and ground the shielding, ideally on both ends.
 
 If you are unsure about your sensor being triggered, check [OctoPrint logs](https://community.octoprint.org/t/where-can-i-find-octoprints-and-octopis-log-files/299)
-
-## Support me
-
-![Luke's 3D](screenshots/Lukes_3D_logo.png "Luke's 3D")
-
-This plugin was developed in my spare time.
-If you find it useful and like it, you can support me by clicking the button below :)
-
-[![More coffee, more code](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5L758LYSUGHW4&source=url)
-
-Have a good one
-
-Luke
 
 ## Screenshots
 

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -418,6 +418,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
             self.paused_for_user = False
             self.printing = True
 
+            if self.setting_cmd_action is 2: # "Do nothing" cmd option
+                return
+
             # print started with no filament present
             if event is Events.PRINT_STARTED and self.plugin_enabled(self.setting_pin):
                 self._logger.info("Starting print.")

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -118,7 +118,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
     def is_filament_present(self, pin, power, triggered_mode):
         if self.read_sensor_multiple(pin, power, triggered_mode):
-            self._logger.info("Filament detected")
+            # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+            # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+            #self._logger.info("Filament detected")
             return 0
         else:
             self._logger.info("Filament not detected")
@@ -140,7 +142,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
             self._printer.pause_print()
 
     def sensor_callback(self, _):
-        self._logger.info("Sensor callback called")
+        # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+        # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+        #self._logger.info("Sensor callback called")
         filamentPresentInt = self.is_filament_present(self.setting_pin, self.setting_power, self.setting_triggered)
         if filamentPresentInt is 1:
             self._logger.info("Sensor was triggered")
@@ -150,7 +154,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
             self._plugin_manager.send_plugin_message(self._identifier, dict(type="filamentStatus", noFilament=True,
                                                                             msg="Printer ran out of filament!"))
         elif filamentPresentInt is 0:
-            self._logger.info("Sensor was not triggered")
+            # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+            # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+            #self._logger.info("Sensor was not triggered")
             # change navbar icon to filament present
             self._plugin_manager.send_plugin_message(self._identifier, dict(type="filamentStatus", noFilament=False,
                                                                             msg="Filament inserted!"))
@@ -357,7 +363,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                                                       msg="Initial filament read"))
 
     def read_sensor_multiple(self, pin, power, trigger_mode):
-        self._logger.info("Reading sensor values")
+        # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+        # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+        #self._logger.info("Reading sensor values")
         oldTrigger = None
         x = 0
 
@@ -375,7 +383,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                 #self._logger.info("Repeating sensor read due to false positives")
 
             if x >= 10:
-                self._logger.info("Reading result: %s" % newTrigger)
+                # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+                # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+                #self._logger.info("Reading result: %s" % newTrigger)
                 return newTrigger
 
     # plugin disabled if pin set to 0

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -370,7 +370,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                 oldTrigger = newTrigger
             elif oldTrigger != newTrigger:
                 x = 0
-                self._logger.info("Repeating sensor read due to false positives")
+                # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+                # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+                #self._logger.info("Repeating sensor read due to false positives")
 
             if x >= 10:
                 self._logger.info("Reading result: %s" % newTrigger)

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -461,12 +461,12 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
                 # version check: github repository
                 type="github_release",
-                user="luckyx182",
+                user="valemaio2",
                 repo="Filament_sensor_simplified",
                 current=self._plugin_version,
 
                 # update method: pip
-                pip="https://github.com/luckyx182/Filament_sensor_simplified/archive/{target_version}.zip"
+                pip="https://github.com/valemaio2/Filament_sensor_simplified/archive/{target_version}.zip"
             )
         )
 

--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -118,7 +118,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
     def is_filament_present(self, pin, power, triggered_mode):
         if self.read_sensor_multiple(pin, power, triggered_mode):
-            self._logger.info("Filament detected")
+            # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+            # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+            #self._logger.info("Filament detected")
             return 0
         else:
             self._logger.info("Filament not detected")
@@ -140,7 +142,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
             self._printer.pause_print()
 
     def sensor_callback(self, _):
-        self._logger.info("Sensor callback called")
+        # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+        # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+        #self._logger.info("Sensor callback called")
         filamentPresentInt = self.is_filament_present(self.setting_pin, self.setting_power, self.setting_triggered)
         if filamentPresentInt is 1:
             self._logger.info("Sensor was triggered")
@@ -150,7 +154,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
             self._plugin_manager.send_plugin_message(self._identifier, dict(type="filamentStatus", noFilament=True,
                                                                             msg="Printer ran out of filament!"))
         elif filamentPresentInt is 0:
-            self._logger.info("Sensor was not triggered")
+            # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+            # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+            #self._logger.info("Sensor was not triggered")
             # change navbar icon to filament present
             self._plugin_manager.send_plugin_message(self._identifier, dict(type="filamentStatus", noFilament=False,
                                                                             msg="Filament inserted!"))
@@ -357,7 +363,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                                                       msg="Initial filament read"))
 
     def read_sensor_multiple(self, pin, power, trigger_mode):
-        self._logger.info("Reading sensor values")
+        # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+        # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+        #self._logger.info("Reading sensor values")
         oldTrigger = None
         x = 0
 
@@ -375,7 +383,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
                 #self._logger.info("Repeating sensor read due to false positives")
 
             if x >= 10:
-                self._logger.info("Reading result: %s" % newTrigger)
+                # Commenting out this info log due to spamming the log file and filling up the memory quickly.
+                # See https://github.com/LuckyX182/Filament_sensor_simplified/issues/64
+                #self._logger.info("Reading result: %s" % newTrigger)
                 return newTrigger
 
     # plugin disabled if pin set to 0
@@ -492,3 +502,4 @@ def __plugin_load__():
         "octoprint.comm.protocol.gcode.received": __plugin_implementation__.gcode_response_received,
         "octoprint.comm.protocol.gcode.sending": __plugin_implementation__.sending_gcode
     }
+

--- a/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
+++ b/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
@@ -70,9 +70,10 @@ $(function () {
                             self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> The pin selected is power, ground or out of range pin number, choose other pin');
                         }
                     },
-                    error: function () {
+                    error: function (jqXHR) {
+                        console.log(JSON.stringify(jqXHR));
                         $("#filamentsensorsimplified_settings_testResult").addClass("alert-error");
-                        self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> There was an error :(');
+                        self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> There was an error &#128542 (check browser console for details)');
                     },
                     success: function (result) {
                         if (result.triggered === 0) {

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
@@ -76,15 +76,18 @@
             <select data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action, disable:printing" required>
                 <option value=0>{{ _('Send G-code') }}</option>
                 <option value=1>{{ _('OctoPrint pause') }}</option>
+                <option value=2>{{ _('Do nothing') }}</option>
             </select>
         </div>
 
         <br/>
-        <label class="control-label" for="filamentsensorsimplified_settings_commandInput">{{ _('G-code') }}</label>
-        <div class="controls">
-            <input id="filamentsensorsimplified_settings_commandInput" type="text" class="input-large" data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.g_code, disable:printing">
-            <span class="margin-top10 help-block" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 0">Which G-code will be sent to printer on filament runout.</span>
-            <span class="margin-top10 help-block" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 1">Which G-code will be sent to printer before pausing print.</span>
+        <div data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() != 2">
+            <label class="control-label" for="filamentsensorsimplified_settings_commandInput">{{ _('G-code') }}</label>
+            <div class="controls">
+                <input id="filamentsensorsimplified_settings_commandInput" type="text" class="input-large" data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.g_code, disable:printing">
+                <span class="margin-top10 help-block" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 0">Which G-code will be sent to printer on filament runout.</span>
+                <span class="margin-top10 help-block" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 1">Which G-code will be sent to printer before pausing print.</span>
+            </div>
         </div>
     </div>
 

--- a/setup.py
+++ b/setup.py
@@ -14,20 +14,22 @@ plugin_package = "octoprint_filamentsensorsimplified"
 plugin_name = "Filament sensor simplified"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.3"
+plugin_version = "0.3.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
 plugin_description = """Simple plugin reacting to filament sensor, issuing filament change gcode to printer on filament runout"""
 
 # The plugin's author. Can be overwritten within OctoPrint's internal data via __plugin_author__ in the plugin module
-plugin_author = "Lukáš Malatinský"
+# plugin_author = "Lukáš Malatinský"
+plugin_author = "Vale Maio"
 
 # The plugin's author's mail address.
-plugin_author_email = "luckyx182@gmail.com"
+# plugin_author_email = "luckyx182@gmail.com"
+plugin_author_email = "vale.maio2@gmail.com"
 
 # The plugin's homepage URL. Can be overwritten within OctoPrint's internal data via __plugin_url__ in the plugin module
-plugin_url = "https://github.com/luckyx182/Filament_sensor_simplified"
+plugin_url = "https://github.com/valemaio2/Filament_sensor_simplified"
 
 # The plugin's license. Can be overwritten within OctoPrint's internal data via __plugin_license__ in the plugin module
 plugin_license = "AGPLv3"


### PR DESCRIPTION
This PR adds 3 small changes:

- Additional info (via the browser's console) when clicking "Test sensor"
- Firing custom events when the sensor is triggered (useful for plugins like https://github.com/tjjfvi/OctoPrint-IFTTT that allow you to subscribe to custom events)
- A 'Do Nothing' action option to perform when the sensor is triggered (useful for users who only want the navbar status & popup  notification or for users who will use the custom events mentioned above to create their own action/notification)